### PR TITLE
Enhancement: Added timeout to Client._get_response

### DIFF
--- a/generic_request_signer/client.py
+++ b/generic_request_signer/client.py
@@ -23,12 +23,12 @@ class Client(object):
             return factory.MultipartSignedRequestFactory
         return factory.SignedRequestFactory
 
-    def _get_response(self, http_method, endpoint, data=None, files=None, **request_kwargs):
+    def _get_response(self, http_method, endpoint, data=None, files=None, timeout=15, **request_kwargs):
         headers = request_kwargs.get("headers", {})
         if not isinstance(data, basestring) and headers.get("Content-Type") == "application/json":
             data = json.dumps(data, default=json_encoder)
         try:
-            http_response = urllib2.urlopen(self._get_request(http_method, endpoint, data, files, **request_kwargs))
+            http_response = urllib2.urlopen(self._get_request(http_method, endpoint, data, files, **request_kwargs), timeout=timeout)
         except urllib2.HTTPError as e:
             http_response = e
         return response.Response(http_response)

--- a/generic_request_signer/tests/client_tests.py
+++ b/generic_request_signer/tests/client_tests.py
@@ -39,7 +39,7 @@ class ClientTests(unittest.TestCase):
     def test_get_response_invokes_urlopen_with_request_return_value(self):
         with mock.patch.object(self.sut_class, '_get_request') as get_request:
             self.sut._get_response('GET', '/', {}, **{})
-        self.urlopen.assert_called_once_with(get_request.return_value)
+        self.urlopen.assert_called_once_with(get_request.return_value, timeout=15)
 
     def test_get_response_encodes_json_data_when_content_type_is_application_json(self):
         request_args = {"headers": {"Content-Type": "application/json"}}
@@ -100,6 +100,11 @@ class ClientTests(unittest.TestCase):
         with mock.patch('generic_request_signer.factory.SignedRequestFactory') as factory:
             result = self.sut._get_request('GET', '/', {}, **{})
         self.assertEqual(result, factory.return_value.create_request.return_value)
+
+    def test_timeout_in_get_response_can_be_overridden(self):
+        with mock.patch.object(self.sut_class, '_get_request') as get_request:
+            self.sut._get_response('GET', '/', {}, timeout=30, **{})
+        self.urlopen.assert_called_once_with(get_request.return_value, timeout=30)
 
 
 class FakeApiCredentials(object):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='generic-request-signer',
-    version='0.3.2',
+    version='0.4.0',
     author='imtapps',
     url='https://github.com/imtapps/generic-request-signer',
     description="A python library for signing http requests.",


### PR DESCRIPTION
Network issues can cause socket connections to hang, and Python socket
connections have no time out by default.

This commit adds an overridable default timeout of 15 seconds.